### PR TITLE
Replace remaining references to 'struct ucontext' with 'ucontext_t'

### DIFF
--- a/src/client/linux/dump_writer_common/ucontext_reader.cc
+++ b/src/client/linux/dump_writer_common/ucontext_reader.cc
@@ -36,19 +36,19 @@ namespace google_breakpad {
 
 // Minidump defines register structures which are different from the raw
 // structures which we get from the kernel. These are platform specific
-// functions to juggle the ucontext and user structures into minidump format.
+// functions to juggle the ucontext_t and user structures into minidump format.
 
 #if defined(__i386__)
 
-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
+uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
   return uc->uc_mcontext.gregs[REG_ESP];
 }
 
-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
+uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
   return uc->uc_mcontext.gregs[REG_EIP];
 }
 
-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
+void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
                                     const struct _libc_fpstate* fp) {
   const greg_t* regs = uc->uc_mcontext.gregs;
 
@@ -88,15 +88,15 @@ void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
 
 #elif defined(__x86_64)
 
-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
+uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
   return uc->uc_mcontext.gregs[REG_RSP];
 }
 
-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
+uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
   return uc->uc_mcontext.gregs[REG_RIP];
 }
 
-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
+void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
                                     const struct _libc_fpstate* fpregs) {
   const greg_t* regs = uc->uc_mcontext.gregs;
 
@@ -145,15 +145,15 @@ void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
 
 #elif defined(__ARM_EABI__)
 
-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
+uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
   return uc->uc_mcontext.arm_sp;
 }
 
-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
+uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
   return uc->uc_mcontext.arm_pc;
 }
 
-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc) {
+void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc) {
   out->context_flags = MD_CONTEXT_ARM_FULL;
 
   out->iregs[0] = uc->uc_mcontext.arm_r0;
@@ -184,15 +184,15 @@ void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc) {
 
 #elif defined(__aarch64__)
 
-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
+uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
   return uc->uc_mcontext.sp;
 }
 
-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
+uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
   return uc->uc_mcontext.pc;
 }
 
-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
+void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
                                     const struct fpsimd_context* fpregs) {
   out->context_flags = MD_CONTEXT_ARM64_FULL;
 
@@ -210,15 +210,15 @@ void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
 
 #elif defined(__mips__)
 
-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
+uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
   return uc->uc_mcontext.gregs[MD_CONTEXT_MIPS_REG_SP];
 }
 
-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
+uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
   return uc->uc_mcontext.pc;
 }
 
-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc) {
+void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc) {
 #if _MIPS_SIM == _ABI64
   out->context_flags = MD_CONTEXT_MIPS64_FULL;
 #elif _MIPS_SIM == _ABIO32

--- a/src/client/linux/dump_writer_common/ucontext_reader.h
+++ b/src/client/linux/dump_writer_common/ucontext_reader.h
@@ -39,23 +39,23 @@
 
 namespace google_breakpad {
 
-// Wraps platform-dependent implementations of accessors to ucontext structs.
+// Wraps platform-dependent implementations of accessors to ucontext_t structs.
 struct UContextReader {
-  static uintptr_t GetStackPointer(const struct ucontext* uc);
+  static uintptr_t GetStackPointer(const ucontext_t* uc);
 
-  static uintptr_t GetInstructionPointer(const struct ucontext* uc);
+  static uintptr_t GetInstructionPointer(const ucontext_t* uc);
 
-  // Juggle a arch-specific ucontext into a minidump format
+  // Juggle a arch-specific ucontext_t into a minidump format
   //   out: the minidump structure
   //   info: the collection of register structures.
 #if defined(__i386__) || defined(__x86_64)
-  static void FillCPUContext(RawContextCPU *out, const ucontext *uc,
+  static void FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
                              const struct _libc_fpstate* fp);
 #elif defined(__aarch64__)
-  static void FillCPUContext(RawContextCPU *out, const ucontext *uc,
+  static void FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
                              const struct fpsimd_context* fpregs);
 #else
-  static void FillCPUContext(RawContextCPU *out, const ucontext *uc);
+  static void FillCPUContext(RawContextCPU *out, const ucontext_t *uc);
 #endif
 };
 

--- a/src/client/linux/handler/exception_handler.cc
+++ b/src/client/linux/handler/exception_handler.cc
@@ -439,9 +439,9 @@ bool ExceptionHandler::HandleSignal(int sig, siginfo_t* info, void* uc) {
   // Fill in all the holes in the struct to make Valgrind happy.
   memset(&g_crash_context_, 0, sizeof(g_crash_context_));
   memcpy(&g_crash_context_.siginfo, info, sizeof(siginfo_t));
-  memcpy(&g_crash_context_.context, uc, sizeof(struct ucontext));
+  memcpy(&g_crash_context_.context, uc, sizeof(ucontext_t));
 #if defined(__aarch64__)
-  struct ucontext* uc_ptr = (struct ucontext*)uc;
+  ucontext_t* uc_ptr = (ucontext_t*)uc;
   struct fpsimd_context* fp_ptr =
       (struct fpsimd_context*)&uc_ptr->uc_mcontext.__reserved;
   if (fp_ptr->head.magic == FPSIMD_MAGIC) {
@@ -450,9 +450,9 @@ bool ExceptionHandler::HandleSignal(int sig, siginfo_t* info, void* uc) {
   }
 #elif !defined(__ARM_EABI__) && !defined(__mips__)
   // FP state is not part of user ABI on ARM Linux.
-  // In case of MIPS Linux FP state is already part of struct ucontext
+  // In case of MIPS Linux FP state is already part of ucontext_t
   // and 'float_state' is not a member of CrashContext.
-  struct ucontext* uc_ptr = (struct ucontext*)uc;
+  ucontext_t* uc_ptr = (ucontext_t*)uc;
   if (uc_ptr->uc_mcontext.fpregs) {
     memcpy(&g_crash_context_.float_state, uc_ptr->uc_mcontext.fpregs,
            sizeof(g_crash_context_.float_state));
@@ -476,7 +476,7 @@ bool ExceptionHandler::SimulateSignalDelivery(int sig) {
   // ExceptionHandler::HandleSignal().
   siginfo.si_code = SI_USER;
   siginfo.si_pid = getpid();
-  struct ucontext context;
+  ucontext_t context;
   getcontext(&context);
   return HandleSignal(sig, &siginfo, &context);
 }

--- a/src/client/linux/handler/exception_handler.h
+++ b/src/client/linux/handler/exception_handler.h
@@ -191,11 +191,11 @@ class ExceptionHandler {
   struct CrashContext {
     siginfo_t siginfo;
     pid_t tid;  // the crashing thread.
-    struct ucontext context;
+    ucontext_t context;
 #if !defined(__ARM_EABI__) && !defined(__mips__)
     // #ifdef this out because FP state is not part of user ABI for Linux ARM.
-    // In case of MIPS Linux FP state is already part of struct
-    // ucontext so 'float_state' is not required.
+    // In case of MIPS Linux FP state is already part of ucontext_t so
+    // 'float_state' is not required.
     fpstate_t float_state;
 #endif
   };

--- a/src/client/linux/microdump_writer/microdump_writer.cc
+++ b/src/client/linux/microdump_writer/microdump_writer.cc
@@ -571,7 +571,7 @@ class MicrodumpWriter {
 
   void* Alloc(unsigned bytes) { return dumper_->allocator()->Alloc(bytes); }
 
-  const struct ucontext* const ucontext_;
+  const ucontext_t* const ucontext_;
 #if !defined(__ARM_EABI__) && !defined(__mips__)
   const google_breakpad::fpstate_t* const float_state_;
 #endif

--- a/src/client/linux/minidump_writer/minidump_writer.cc
+++ b/src/client/linux/minidump_writer/minidump_writer.cc
@@ -1248,7 +1248,7 @@ class MinidumpWriter {
   const int fd_;  // File descriptor where the minidum should be written.
   const char* path_;  // Path to the file where the minidum should be written.
 
-  const struct ucontext* const ucontext_;  // also from the signal handler
+  const ucontext_t* const ucontext_;  // also from the signal handler
 #if !defined(__ARM_EABI__) && !defined(__mips__)
   const google_breakpad::fpstate_t* const float_state_;  // ditto
 #endif


### PR DESCRIPTION
This relands
https://chromium.googlesource.com/breakpad/breakpad/src/+/e3035bc406cee8a4d765e59ad46eb828705f17f4,
which was accidentally committed to breakpad/breakpad/src, the read-only
mirror of src in breakpad/breakpad. (Well, it should have been
read-only.) See https://crbug.com/766164.

This fixes issues with glibc-2.26.

See https://bugs.gentoo.org/show_bug.cgi?id=628782 ,
https://sourceware.org/git/?p=glibc.git;h=251287734e89a52da3db682a8241eb6bccc050c9 , and
https://sourceware.org/ml/libc-alpha/2017-08/msg00010.html for context.
Change-Id: Id66f474d636dd2afa450bab925c5514a800fdd6f
Reviewed-on: https://chromium-review.googlesource.com/674304
Reviewed-by: Mark Mentovai <mark@chromium.org>